### PR TITLE
Use keyspace primary ranges for CASSANDRA-9639

### DIFF
--- a/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
+++ b/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
@@ -68,12 +68,10 @@ public class SizeEstimatesRecorder extends MigrationListener implements Runnable
 
         logger.trace("Recording size estimates");
 
-        // find primary token ranges for the local node.
-        Collection<Token> localTokens = StorageService.instance.getLocalTokens();
-        Collection<Range<Token>> localRanges = metadata.getPrimaryRangesFor(localTokens);
-
         for (Keyspace keyspace : Keyspace.nonLocalStrategy())
         {
+            Collection<Range<Token>> localRanges = StorageService.instance.getPrimaryRangesForEndpoint(keyspace.getName(),
+                    FBUtilities.getBroadcastAddress());
             for (ColumnFamilyStore table : keyspace.getColumnFamilyStores())
             {
                 long start = System.nanoTime();


### PR DESCRIPTION
The primary ranges will differ based on the keyspace and replication strategy/factor. Particularly true of vnode/multi DC environments where the TokenMetadata.getPredecessor of each local token is not necessarily the bounds of the primary ranges.